### PR TITLE
Fix TransferFormModal cancel button styling

### DIFF
--- a/client/src/components/transfer/TransferFormModal.jsx
+++ b/client/src/components/transfer/TransferFormModal.jsx
@@ -239,7 +239,9 @@ const TransferFormModal = ({ open, onClose, initialValues }) => {
           </Grid>
         </DialogContent>
         <DialogActions>
-          <Button onClick={onClose}>Cancel</Button>
+          <Button onClick={onClose} variant="outlined">
+            Cancel
+          </Button>
           <Button
             type="submit"
             variant="contained"


### PR DESCRIPTION
## Summary
- outline cancel button in TransferFormModal for consistency

## Testing
- `npm run lint --prefix client` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e98994a608320acce8fce61177525