### PR TITLE
Finish processing module

### DIFF
--- a/client/src/components/Processing.jsx
+++ b/client/src/components/Processing.jsx
@@ -41,7 +41,7 @@ import { useGetStoragesQuery } from "../services/storageApi";
 
 const Processing = () => {
   const [manufacturingUnits, setManufacturingUnits] = useState([]);
-  const [tamarindTypes, setTamarindTypes] = useState([]);
+  const tamarindTypes = ["Whole", "Raw Pod", "Seedless", "Sour"];
   const [formData, setFormData] = useState({
     date: new Date().toISOString().split("T")[0],
     manufacturingUnit: "",
@@ -63,7 +63,7 @@ const Processing = () => {
 
   const { data: processingRecords = [], isLoading: isLoadingProcessing } =
     useGetProcessingLogsQuery();
-  const { data: storageData = [] } = useGetStoragesQuery("manufacturing");
+  const { data: storageData = [] } = useGetStoragesQuery("unit");
   const [createProcessingLog] = useCreateProcessingLogMutation();
   const [updateProcessingLog] = useUpdateProcessingLogMutation();
   const [deleteProcessingLog] = useDeleteProcessingLogMutation();
@@ -131,7 +131,7 @@ const Processing = () => {
       date: new Date(record.date).toISOString().split("T")[0],
       manufacturingUnit: record.manufacturingUnit._id,
       inputs: record.inputs.map((input) => ({
-        tamarindType: input.tamarindType._id,
+        tamarindType: input.tamarindType,
         quantity: input.quantity,
       })),
       output: {
@@ -217,8 +217,7 @@ const Processing = () => {
                   <TableCell>
                     {record.inputs
                       .map(
-                        (input) =>
-                          `${input.tamarindType.name} (${input.quantity}kg)`
+                        (input) => `${input.tamarindType} (${input.quantity}kg)`
                       )
                       .join(", ")}
                   </TableCell>
@@ -302,8 +301,8 @@ const Processing = () => {
                           label="Tamarind Type"
                         >
                           {tamarindTypes.map((type) => (
-                            <MenuItem key={type._id} value={type._id}>
-                              {type.name}
+                            <MenuItem key={type} value={type}>
+                              {type}
                             </MenuItem>
                           ))}
                         </Select>

--- a/server/controllers/processingController.js
+++ b/server/controllers/processingController.js
@@ -6,10 +6,13 @@ exports.createProcessing = async (req, res) => {
   try {
     const { date, manufacturingUnit, inputs, output, team, notes } = req.body;
 
-    // Validate manufacturing unit exists
+    // Validate manufacturing unit exists and is of type 'unit'
     const unit = await Storage.findById(manufacturingUnit);
     if (!unit) {
       return res.status(404).json({ message: "Manufacturing unit not found" });
+    }
+    if (unit.type !== "unit") {
+      return res.status(400).json({ message: "Processing can only be done in manufacturing units" });
     }
 
     const processing = new Processing({
@@ -34,7 +37,6 @@ exports.getAllProcessing = async (req, res) => {
   try {
     const processing = await Processing.find()
       .populate("manufacturingUnit", "name")
-      .populate("inputs.tamarindType", "name")
       .populate("createdBy", "name")
       .sort({ date: -1 });
     res.json(processing);
@@ -48,7 +50,6 @@ exports.getProcessingById = async (req, res) => {
   try {
     const processing = await Processing.findById(req.params.id)
       .populate("manufacturingUnit", "name")
-      .populate("inputs.tamarindType", "name")
       .populate("createdBy", "name");
 
     if (!processing) {

--- a/server/models/Processing.js
+++ b/server/models/Processing.js
@@ -15,8 +15,7 @@ const processingSchema = new mongoose.Schema(
     inputs: [
       {
         tamarindType: {
-          type: mongoose.Schema.Types.ObjectId,
-          ref: "TamarindType",
+          type: String,
           required: true,
         },
         quantity: {


### PR DESCRIPTION
## Summary
- store tamarind types as strings in Processing model
- validate that processing only occurs in unit storages and simplify populates
- fetch unit storages in the Processing page and use a fixed tamarind type list

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685f62b8b1f88320814175934c0b54a7