### PR TITLE
Fix sales form item cloning issue

### DIFF
--- a/client/src/components/sales/SalesFormModal.jsx
+++ b/client/src/components/sales/SalesFormModal.jsx
@@ -44,7 +44,7 @@ const SalesFormModal = ({ open, onClose, onSubmit, initialValues }) => {
       dueDate: "",
       amountPaid: "",
       notes: "",
-      items: [defaultItem],
+      items: [JSON.parse(JSON.stringify(defaultItem))],
       ...initialValues,
     },
     validationSchema,
@@ -60,7 +60,10 @@ const SalesFormModal = ({ open, onClose, onSubmit, initialValues }) => {
   });
 
   const addItem = () => {
-    formik.setFieldValue("items", [...formik.values.items, defaultItem]);
+    formik.setFieldValue("items", [
+      ...formik.values.items,
+      JSON.parse(JSON.stringify(defaultItem)),
+    ]);
   };
 
   const removeItem = (idx) => {


### PR DESCRIPTION
## Summary
- create new object for each sales item
- avoid shared object references to allow independent edits

## Testing
- `npm --prefix client run lint` *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685f7dd89bc0832089c43fa433a41896