### PR TITLE
Add supplier payments module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,21 @@
 # InventTama Full-Stack Project
 
-Frontend: Vite + React
-Backend: Node.js + Express
+Frontend: Vite + React (in `client/`)
+Backend: Node.js + Express (in `server/`)
+
+## Supplier Payments Module
+
+This module records payments made to suppliers. Payments reduce the supplier's
+`outstandingBalance` and support multiple payment modes (cash, bank transfer or
+UPI). Each supplier profile can display its payment history, while queries allow
+filtering by supplier, date range and payment mode.
+
+### Running the Frontend
+
+From the repository root:
+
+```bash
+npm run client
+```
+
+This starts the React app located in the `client/` folder.

--- a/client/src/components/supplierPayments/PaymentFormModal.jsx
+++ b/client/src/components/supplierPayments/PaymentFormModal.jsx
@@ -1,0 +1,134 @@
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Grid, TextField, MenuItem } from "@mui/material";
+import { useFormik } from "formik";
+import * as Yup from "yup";
+import { useGetSuppliersQuery } from "../../services/suppliersApi";
+
+const validationSchema = Yup.object({
+  supplier: Yup.string().required("Supplier is required"),
+  amount: Yup.number().moreThan(0).required("Amount is required"),
+  paymentDate: Yup.string().required("Date is required"),
+  paymentMode: Yup.string().required("Mode is required"),
+});
+
+const PaymentFormModal = ({ open, onClose, onSubmit, initialValues }) => {
+  const { data: suppliers = [] } = useGetSuppliersQuery();
+
+  const formik = useFormik({
+    initialValues: {
+      supplier: "",
+      amount: "",
+      paymentDate: new Date().toISOString().split("T")[0],
+      paymentMode: "cash",
+      upiTransactionId: "",
+      notes: "",
+      ...initialValues,
+    },
+    validationSchema,
+    enableReinitialize: true,
+    onSubmit: (values) => {
+      onSubmit(values);
+      onClose();
+    },
+  });
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>{initialValues ? "Edit" : "Add"} Payment</DialogTitle>
+      <form onSubmit={formik.handleSubmit}>
+        <DialogContent>
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                select
+                fullWidth
+                label="Supplier"
+                name="supplier"
+                value={formik.values.supplier}
+                onChange={formik.handleChange}
+                error={Boolean(formik.errors.supplier)}
+                helperText={formik.errors.supplier}
+              >
+                {suppliers.map((s) => (
+                  <MenuItem key={s._id} value={s._id}>
+                    {s.name}
+                  </MenuItem>
+                ))}
+              </TextField>
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                fullWidth
+                type="number"
+                label="Amount"
+                name="amount"
+                value={formik.values.amount}
+                onChange={formik.handleChange}
+                error={Boolean(formik.errors.amount)}
+                helperText={formik.errors.amount}
+              />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                type="date"
+                fullWidth
+                label="Payment Date"
+                name="paymentDate"
+                value={formik.values.paymentDate}
+                onChange={formik.handleChange}
+                InputLabelProps={{ shrink: true }}
+                error={Boolean(formik.errors.paymentDate)}
+                helperText={formik.errors.paymentDate}
+              />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                select
+                fullWidth
+                label="Payment Mode"
+                name="paymentMode"
+                value={formik.values.paymentMode}
+                onChange={formik.handleChange}
+                error={Boolean(formik.errors.paymentMode)}
+                helperText={formik.errors.paymentMode}
+              >
+                <MenuItem value="cash">Cash</MenuItem>
+                <MenuItem value="bank">Bank Transfer</MenuItem>
+                <MenuItem value="upi">UPI</MenuItem>
+              </TextField>
+            </Grid>
+            {formik.values.paymentMode === "upi" && (
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  fullWidth
+                  label="UPI Txn ID"
+                  name="upiTransactionId"
+                  value={formik.values.upiTransactionId}
+                  onChange={formik.handleChange}
+                />
+              </Grid>
+            )}
+            <Grid item xs={12}>
+              <TextField
+                fullWidth
+                multiline
+                rows={2}
+                label="Notes"
+                name="notes"
+                value={formik.values.notes}
+                onChange={formik.handleChange}
+              />
+            </Grid>
+          </Grid>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose}>Cancel</Button>
+          <Button type="submit" variant="contained">
+            {initialValues ? "Update" : "Create"}
+          </Button>
+        </DialogActions>
+      </form>
+    </Dialog>
+  );
+};
+
+export default PaymentFormModal;

--- a/client/src/layouts/Sidebar.jsx
+++ b/client/src/layouts/Sidebar.jsx
@@ -36,6 +36,7 @@ const menuItems = [
   { text: "Transfers", icon: <LocalOffer />, path: "/transfers" },
   { text: "Processing", icon: <Factory />, path: "/processing" },
   { text: "Sales", icon: <AccountBalance />, path: "/sales" },
+  { text: "Supplier Payments", icon: <Inventory />, path: "/supplier-payments" },
   {
     text: "Supplier Management",
     icon: <Business />,

--- a/client/src/pages/SupplierPayments.jsx
+++ b/client/src/pages/SupplierPayments.jsx
@@ -1,0 +1,110 @@
+import { Box, Typography, Button, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, CircularProgress, IconButton, Tooltip, Dialog, DialogTitle, DialogActions } from "@mui/material";
+import EditIcon from "@mui/icons-material/Edit";
+import DeleteIcon from "@mui/icons-material/Delete";
+import { useState } from "react";
+import PaymentFormModal from "../components/supplierPayments/PaymentFormModal";
+import { useGetPaymentsQuery, useCreatePaymentMutation, useUpdatePaymentMutation, useDeletePaymentMutation } from "../services/supplierPaymentApi";
+import { useGetSuppliersQuery } from "../services/suppliersApi";
+
+const SupplierPayments = () => {
+  const { data: payments, isLoading } = useGetPaymentsQuery();
+  const { data: suppliers } = useGetSuppliersQuery();
+  const [createPayment] = useCreatePaymentMutation();
+  const [updatePayment] = useUpdatePaymentMutation();
+  const [deletePayment] = useDeletePaymentMutation();
+
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editData, setEditData] = useState(null);
+  const [deleteDialog, setDeleteDialog] = useState({ open: false, id: null });
+
+  const openModal = (payment = null) => {
+    setEditData(payment);
+    setModalOpen(true);
+  };
+
+  const closeModal = () => {
+    setModalOpen(false);
+    setEditData(null);
+  };
+
+  const handleSubmit = async (data) => {
+    if (editData) {
+      await updatePayment({ id: editData._id, ...data });
+    } else {
+      await createPayment(data);
+    }
+  };
+
+  const confirmDelete = async () => {
+    await deletePayment(deleteDialog.id);
+    setDeleteDialog({ open: false, id: null });
+  };
+
+  const getSupplierName = (id) => {
+    const s = suppliers?.find((sup) => sup._id === id);
+    return s?.name || id;
+  };
+
+  return (
+    <Box>
+      <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
+        <Typography variant="h5">Supplier Payments</Typography>
+        <Button variant="contained" onClick={() => openModal()}>Add Payment</Button>
+      </Box>
+
+      <PaymentFormModal open={modalOpen} onClose={closeModal} onSubmit={handleSubmit} initialValues={editData} />
+
+      <Dialog open={deleteDialog.open} onClose={() => setDeleteDialog({ open: false, id: null })}>
+        <DialogTitle>Delete this payment?</DialogTitle>
+        <DialogActions>
+          <Button onClick={() => setDeleteDialog({ open: false, id: null })}>Cancel</Button>
+          <Button color="error" onClick={confirmDelete}>Delete</Button>
+        </DialogActions>
+      </Dialog>
+
+      {isLoading ? (
+        <CircularProgress />
+      ) : (
+        <TableContainer component={Paper}>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Date</TableCell>
+                <TableCell>Supplier</TableCell>
+                <TableCell>Amount</TableCell>
+                <TableCell>Mode</TableCell>
+                <TableCell>Notes</TableCell>
+                <TableCell align="center">Actions</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {payments?.map((p) => (
+                <TableRow key={p._id}>
+                  <TableCell>{new Date(p.paymentDate).toLocaleDateString()}</TableCell>
+                  <TableCell>{p.supplier?.name || getSupplierName(p.supplier)}</TableCell>
+                  <TableCell>{p.amount}</TableCell>
+                  <TableCell>{p.paymentMode}</TableCell>
+                  <TableCell>{p.notes}</TableCell>
+                  <TableCell align="center">
+                    <Tooltip title="Edit">
+                      <IconButton size="small" onClick={() => openModal(p)}>
+                        <EditIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Delete">
+                      <IconButton size="small" color="error" onClick={() => setDeleteDialog({ open: true, id: p._id })}>
+                        <DeleteIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+    </Box>
+  );
+};
+
+export default SupplierPayments;

--- a/client/src/routes/AppRoutes.jsx
+++ b/client/src/routes/AppRoutes.jsx
@@ -10,6 +10,7 @@ import Dashboard from "../pages/Dashboard";
 import SupplierPage from "../pages/SupplierPage";
 import CustomerPage from "../pages/CustomerPage";
 import StorageAndLotPage from "../pages/StorageAndLotPage";
+import SupplierPayments from "../pages/SupplierPayments";
 
 const router = createBrowserRouter([
   {
@@ -41,6 +42,10 @@ const router = createBrowserRouter([
           {
             path: "/sales",
             element: <Sales />,
+          },
+          {
+            path: "/supplier-payments",
+            element: <SupplierPayments />,
           },
           {
             path: "/supplier-management",

--- a/client/src/services/apiSlice.js
+++ b/client/src/services/apiSlice.js
@@ -23,6 +23,7 @@ export const apiSlice = createApi({
     "SupplierCredit",
     "SeedSales",
     "Inventory",
+    "SupplierPayment",
     "User",
   ],
   endpoints: () => ({}),

--- a/client/src/services/supplierPaymentApi.js
+++ b/client/src/services/supplierPaymentApi.js
@@ -1,0 +1,47 @@
+import { apiSlice } from "./apiSlice";
+
+export const supplierPaymentApi = apiSlice.injectEndpoints({
+  endpoints: (builder) => ({
+    getPayments: builder.query({
+      query: (params) => ({
+        url: "/supplier-payments",
+        params,
+      }),
+      providesTags: ["SupplierPayment"],
+    }),
+    getPayment: builder.query({
+      query: (id) => `/supplier-payments/${id}`,
+    }),
+    createPayment: builder.mutation({
+      query: (data) => ({
+        url: "/supplier-payments",
+        method: "POST",
+        body: data,
+      }),
+      invalidatesTags: ["SupplierPayment", "Supplier"],
+    }),
+    updatePayment: builder.mutation({
+      query: ({ id, ...data }) => ({
+        url: `/supplier-payments/${id}`,
+        method: "PUT",
+        body: data,
+      }),
+      invalidatesTags: ["SupplierPayment", "Supplier"],
+    }),
+    deletePayment: builder.mutation({
+      query: (id) => ({
+        url: `/supplier-payments/${id}`,
+        method: "DELETE",
+      }),
+      invalidatesTags: ["SupplierPayment", "Supplier"],
+    }),
+  }),
+});
+
+export const {
+  useGetPaymentsQuery,
+  useGetPaymentQuery,
+  useCreatePaymentMutation,
+  useUpdatePaymentMutation,
+  useDeletePaymentMutation,
+} = supplierPaymentApi;

--- a/server/controllers/supplierPaymentController.js
+++ b/server/controllers/supplierPaymentController.js
@@ -1,0 +1,106 @@
+const SupplierPayment = require("../models/SupplierPayment");
+const Supplier = require("../models/Supplier");
+
+exports.createPayment = async (req, res) => {
+  try {
+    const payment = new SupplierPayment(req.body);
+    await payment.save();
+
+    const supplier = await Supplier.findById(payment.supplier);
+    if (supplier) {
+      supplier.outstandingBalance =
+        (supplier.outstandingBalance || 0) - payment.amount;
+      await supplier.save();
+    }
+
+    res.status(201).json(payment);
+  } catch (error) {
+    res.status(400).json({ error: "Failed to create payment", details: error.message });
+  }
+};
+
+exports.getAllPayments = async (req, res) => {
+  try {
+    const { supplier, startDate, endDate, mode } = req.query;
+    const filter = {};
+    if (supplier) filter.supplier = supplier;
+    if (mode) filter.paymentMode = mode;
+    if (startDate || endDate) {
+      filter.paymentDate = {};
+      if (startDate) filter.paymentDate.$gte = new Date(startDate);
+      if (endDate) filter.paymentDate.$lte = new Date(endDate);
+    }
+    const payments = await SupplierPayment.find(filter).populate("supplier");
+    res.json(payments);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+};
+
+exports.getPaymentById = async (req, res) => {
+  try {
+    const payment = await SupplierPayment.findById(req.params.id).populate("supplier");
+    if (!payment) return res.status(404).json({ error: "Payment not found" });
+    res.json(payment);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+};
+
+exports.updatePayment = async (req, res) => {
+  try {
+    const payment = await SupplierPayment.findById(req.params.id);
+    if (!payment) return res.status(404).json({ error: "Payment not found" });
+
+    const oldAmount = payment.amount;
+    const oldSupplier = payment.supplier.toString();
+
+    payment.set(req.body);
+    await payment.save();
+
+    if (oldSupplier !== payment.supplier.toString()) {
+      const prevSupplier = await Supplier.findById(oldSupplier);
+      if (prevSupplier) {
+        prevSupplier.outstandingBalance =
+          (prevSupplier.outstandingBalance || 0) + oldAmount;
+        await prevSupplier.save();
+      }
+      const newSupplier = await Supplier.findById(payment.supplier);
+      if (newSupplier) {
+        newSupplier.outstandingBalance =
+          (newSupplier.outstandingBalance || 0) - payment.amount;
+        await newSupplier.save();
+      }
+    } else if (oldAmount !== payment.amount) {
+      const diff = payment.amount - oldAmount;
+      const supplier = await Supplier.findById(payment.supplier);
+      if (supplier) {
+        supplier.outstandingBalance =
+          (supplier.outstandingBalance || 0) - diff;
+        await supplier.save();
+      }
+    }
+
+    res.json(payment);
+  } catch (error) {
+    res.status(400).json({ error: "Failed to update payment", details: error.message });
+  }
+};
+
+exports.deletePayment = async (req, res) => {
+  try {
+    const payment = await SupplierPayment.findByIdAndDelete(req.params.id);
+    if (!payment) return res.status(404).json({ error: "Payment not found" });
+
+    const supplier = await Supplier.findById(payment.supplier);
+    if (supplier) {
+      supplier.outstandingBalance =
+        (supplier.outstandingBalance || 0) + payment.amount;
+      await supplier.save();
+    }
+
+    res.json({ message: "Payment deleted" });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+};

--- a/server/models/SupplierPayment.js
+++ b/server/models/SupplierPayment.js
@@ -1,0 +1,30 @@
+const mongoose = require("mongoose");
+
+const supplierPaymentSchema = new mongoose.Schema(
+  {
+    supplier: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Supplier",
+      required: true,
+    },
+    amount: {
+      type: Number,
+      required: true,
+    },
+    paymentDate: {
+      type: Date,
+      default: Date.now,
+    },
+    paymentMode: {
+      type: String,
+      enum: ["cash", "bank", "upi"],
+      required: true,
+    },
+    upiTransactionId: String,
+    upiScreenshot: String,
+    notes: String,
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model("SupplierPayment", supplierPaymentSchema);

--- a/server/routes/supplierPaymentRoutes.js
+++ b/server/routes/supplierPaymentRoutes.js
@@ -1,0 +1,11 @@
+const express = require("express");
+const router = express.Router();
+const controller = require("../controllers/supplierPaymentController");
+
+router.post("/", controller.createPayment);
+router.get("/", controller.getAllPayments);
+router.get("/:id", controller.getPaymentById);
+router.put("/:id", controller.updatePayment);
+router.delete("/:id", controller.deletePayment);
+
+module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -10,6 +10,7 @@ const authRoutes = require("./routes/authRoutes");
 const supplierRoutes = require("./routes/supplierRoutes");
 const customerRoutes = require("./routes/CustomerRoutes");
 const lotRoutes = require("./routes/lotRoutes");
+const supplierPaymentRoutes = require("./routes/supplierPaymentRoutes");
 
 dotenv.config();
 connectDB();
@@ -23,6 +24,7 @@ app.use("/api/unit-transfers", unitTransferRoutes);
 app.use("/api/sales", saleRoutes);
 app.use("/api/auth", authRoutes);
 app.use("/api/suppliers", supplierRoutes);
+app.use("/api/supplier-payments", supplierPaymentRoutes);
 app.use("/api/customers", customerRoutes);
 app.use("/api", storageRoutes);
 app.use("/api/purchases", require("./routes/purchaseRoutes"));


### PR DESCRIPTION
## Summary
- add SupplierPayments model
- create controller and routes for supplier payments
- expose supplier payment endpoints in API server
- extend frontend API slice and add supplierPayment API service
- add Supplier Payments page with form modal
- wire new route and sidebar entry
- document how to run the frontend

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_685f80ca62e0832096d8ebf51be5789f