### PR TITLE
Add frontend for customer receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,19 @@ This module records payments made to suppliers. Payments reduce the supplier's
 UPI). Each supplier profile can display its payment history, while queries allow
 filtering by supplier, date range and payment mode.
 
+## Customer Receipts Module
+
+Tracks incoming payments against sales invoices. Receipts can settle one or many
+invoices and support partial payments. Each receipt has an auto-generated
+`receiptNumber` and records the payment mode (cash, UPI, bank transfer or
+cheque). Overpayments are prevented and the related sales invoices as well as
+the customer's `outstandingBalance` are updated after each receipt. Receipts can
+be edited or soft deleted and reports will show total received and outstanding
+per customer.
+
+The frontend includes a **Customer Receipts** page accessible from the sidebar
+menu. Use it to record payments received and manage existing receipts.
+
 ### Running the Frontend
 
 From the repository root:

--- a/client/src/components/customerReceipts/ReceiptFormModal.jsx
+++ b/client/src/components/customerReceipts/ReceiptFormModal.jsx
@@ -1,0 +1,182 @@
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Grid,
+  TextField,
+  MenuItem,
+  IconButton,
+} from "@mui/material";
+import { RemoveCircle } from "@mui/icons-material";
+import { useFormik } from "formik";
+import * as Yup from "yup";
+import { useGetCustomersQuery } from "../../services/customersApi";
+import { useGetSalesQuery } from "../../services/salesApi";
+
+const invoiceSchema = Yup.object({
+  sale: Yup.string().required("Invoice is required"),
+  amount: Yup.number().moreThan(0).required("Amount is required"),
+});
+
+const validationSchema = Yup.object({
+  customer: Yup.string().required("Customer is required"),
+  paymentMode: Yup.string().required("Payment mode is required"),
+  paymentDate: Yup.string().required("Date is required"),
+  invoices: Yup.array().of(invoiceSchema).min(1, "At least one invoice"),
+});
+
+const defaultInvoice = { sale: "", amount: "" };
+
+const ReceiptFormModal = ({ open, onClose, onSubmit, initialValues }) => {
+  const { data: customers = [] } = useGetCustomersQuery();
+  const { data: sales = [] } = useGetSalesQuery();
+
+  const formik = useFormik({
+    initialValues: {
+      customer: "",
+      paymentMode: "cash",
+      paymentDate: new Date().toISOString().split("T")[0],
+      referenceNo: "",
+      invoices: [JSON.parse(JSON.stringify(defaultInvoice))],
+      ...initialValues,
+    },
+    validationSchema,
+    enableReinitialize: true,
+    onSubmit: (values) => {
+      onSubmit(values);
+      onClose();
+    },
+  });
+
+  const addInvoice = () => {
+    formik.setFieldValue("invoices", [
+      ...formik.values.invoices,
+      JSON.parse(JSON.stringify(defaultInvoice)),
+    ]);
+  };
+
+  const removeInvoice = (idx) => {
+    const arr = formik.values.invoices.filter((_, i) => i !== idx);
+    formik.setFieldValue("invoices", arr);
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
+      <DialogTitle>{initialValues ? "Edit" : "Add"} Receipt</DialogTitle>
+      <form onSubmit={formik.handleSubmit}>
+        <DialogContent>
+          <Grid container spacing={2} mb={2}>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                select
+                fullWidth
+                label="Customer"
+                name="customer"
+                value={formik.values.customer}
+                onChange={formik.handleChange}
+                error={Boolean(formik.errors.customer)}
+                helperText={formik.errors.customer}
+              >
+                {customers.map((c) => (
+                  <MenuItem key={c._id} value={c._id}>
+                    {c.name}
+                  </MenuItem>
+                ))}
+              </TextField>
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                type="date"
+                fullWidth
+                label="Payment Date"
+                name="paymentDate"
+                value={formik.values.paymentDate}
+                onChange={formik.handleChange}
+                InputLabelProps={{ shrink: true }}
+                error={Boolean(formik.errors.paymentDate)}
+                helperText={formik.errors.paymentDate}
+              />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                select
+                fullWidth
+                label="Payment Mode"
+                name="paymentMode"
+                value={formik.values.paymentMode}
+                onChange={formik.handleChange}
+                error={Boolean(formik.errors.paymentMode)}
+                helperText={formik.errors.paymentMode}
+              >
+                <MenuItem value="cash">Cash</MenuItem>
+                <MenuItem value="upi">UPI</MenuItem>
+                <MenuItem value="bank">Bank Transfer</MenuItem>
+                <MenuItem value="cheque">Cheque</MenuItem>
+              </TextField>
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                fullWidth
+                label="Reference No"
+                name="referenceNo"
+                value={formik.values.referenceNo}
+                onChange={formik.handleChange}
+              />
+            </Grid>
+          </Grid>
+
+          {formik.values.invoices.map((inv, idx) => (
+            <Grid container spacing={2} key={idx} alignItems="center" mb={1}>
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  select
+                  fullWidth
+                  label="Sale Invoice"
+                  name={`invoices[${idx}].sale`}
+                  value={inv.sale}
+                  onChange={formik.handleChange}
+                  error={formik.errors.invoices?.[idx]?.sale}
+                  helperText={formik.errors.invoices?.[idx]?.sale}
+                >
+                  {sales.map((s) => (
+                    <MenuItem key={s._id} value={s._id}>
+                      {s._id}
+                    </MenuItem>
+                  ))}
+                </TextField>
+              </Grid>
+              <Grid item xs={12} sm={4}>
+                <TextField
+                  fullWidth
+                  label="Amount"
+                  type="number"
+                  name={`invoices[${idx}].amount`}
+                  value={inv.amount}
+                  onChange={formik.handleChange}
+                  error={formik.errors.invoices?.[idx]?.amount}
+                  helperText={formik.errors.invoices?.[idx]?.amount}
+                />
+              </Grid>
+              <Grid item xs={12} sm={2}>
+                <IconButton color="error" onClick={() => removeInvoice(idx)}>
+                  <RemoveCircle />
+                </IconButton>
+              </Grid>
+            </Grid>
+          ))}
+          <Button onClick={addInvoice}>Add Invoice</Button>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose}>Cancel</Button>
+          <Button type="submit" variant="contained">
+            {initialValues ? "Update" : "Create"}
+          </Button>
+        </DialogActions>
+      </form>
+    </Dialog>
+  );
+};
+
+export default ReceiptFormModal;

--- a/client/src/layouts/Sidebar.jsx
+++ b/client/src/layouts/Sidebar.jsx
@@ -37,6 +37,7 @@ const menuItems = [
   { text: "Processing", icon: <Factory />, path: "/processing" },
   { text: "Sales", icon: <AccountBalance />, path: "/sales" },
   { text: "Supplier Payments", icon: <Inventory />, path: "/supplier-payments" },
+  { text: "Customer Receipts", icon: <PeopleOutlineOutlined />, path: "/customer-receipts" },
   {
     text: "Supplier Management",
     icon: <Business />,

--- a/client/src/pages/CustomerReceipts.jsx
+++ b/client/src/pages/CustomerReceipts.jsx
@@ -1,0 +1,139 @@
+import {
+  Box,
+  Typography,
+  Button,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  CircularProgress,
+  IconButton,
+  Tooltip,
+  Dialog,
+  DialogTitle,
+  DialogActions,
+} from "@mui/material";
+import EditIcon from "@mui/icons-material/Edit";
+import DeleteIcon from "@mui/icons-material/Delete";
+import { useState } from "react";
+import ReceiptFormModal from "../components/customerReceipts/ReceiptFormModal";
+import {
+  useGetReceiptsQuery,
+  useCreateReceiptMutation,
+  useUpdateReceiptMutation,
+  useDeleteReceiptMutation,
+} from "../services/customerReceiptApi";
+
+const CustomerReceipts = () => {
+  const { data: receipts, isLoading } = useGetReceiptsQuery();
+  const [createReceipt] = useCreateReceiptMutation();
+  const [updateReceipt] = useUpdateReceiptMutation();
+  const [deleteReceipt] = useDeleteReceiptMutation();
+
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editData, setEditData] = useState(null);
+  const [deleteDialog, setDeleteDialog] = useState({ open: false, id: null });
+
+  const openModal = (data = null) => {
+    setEditData(data);
+    setModalOpen(true);
+  };
+
+  const closeModal = () => {
+    setModalOpen(false);
+    setEditData(null);
+  };
+
+  const handleSubmit = async (data) => {
+    if (editData) {
+      await updateReceipt({ id: editData._id, ...data });
+    } else {
+      await createReceipt(data);
+    }
+  };
+
+  const confirmDelete = async () => {
+    await deleteReceipt(deleteDialog.id);
+    setDeleteDialog({ open: false, id: null });
+  };
+
+  const getCustomerName = (receipt) => receipt.customer?.name || receipt.customer;
+
+  return (
+    <Box>
+      <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
+        <Typography variant="h5">Customer Receipts</Typography>
+        <Button variant="contained" onClick={() => openModal()}>Add Receipt</Button>
+      </Box>
+
+      <ReceiptFormModal
+        open={modalOpen}
+        onClose={closeModal}
+        onSubmit={handleSubmit}
+        initialValues={editData}
+      />
+
+      <Dialog
+        open={deleteDialog.open}
+        onClose={() => setDeleteDialog({ open: false, id: null })}
+      >
+        <DialogTitle>Delete this receipt?</DialogTitle>
+        <DialogActions>
+          <Button onClick={() => setDeleteDialog({ open: false, id: null })}>Cancel</Button>
+          <Button color="error" onClick={confirmDelete}>Delete</Button>
+        </DialogActions>
+      </Dialog>
+
+      {isLoading ? (
+        <CircularProgress />
+      ) : (
+        <TableContainer component={Paper}>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Date</TableCell>
+                <TableCell>Customer</TableCell>
+                <TableCell>Total Amount</TableCell>
+                <TableCell>Mode</TableCell>
+                <TableCell>Reference</TableCell>
+                <TableCell align="center">Actions</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {receipts?.map((r) => (
+                <TableRow key={r._id}>
+                  <TableCell>{new Date(r.paymentDate).toLocaleDateString()}</TableCell>
+                  <TableCell>{getCustomerName(r)}</TableCell>
+                  <TableCell>{r.totalAmount}</TableCell>
+                  <TableCell>{r.paymentMode}</TableCell>
+                  <TableCell>{r.referenceNo}</TableCell>
+                  <TableCell align="center">
+                    <Tooltip title="Edit">
+                      <IconButton size="small" onClick={() => openModal(r)}>
+                        <EditIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Delete">
+                      <IconButton
+                        size="small"
+                        color="error"
+                        onClick={() => setDeleteDialog({ open: true, id: r._id })}
+                      >
+                        <DeleteIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+    </Box>
+  );
+};
+
+export default CustomerReceipts;

--- a/client/src/routes/AppRoutes.jsx
+++ b/client/src/routes/AppRoutes.jsx
@@ -11,6 +11,7 @@ import SupplierPage from "../pages/SupplierPage";
 import CustomerPage from "../pages/CustomerPage";
 import StorageAndLotPage from "../pages/StorageAndLotPage";
 import SupplierPayments from "../pages/SupplierPayments";
+import CustomerReceipts from "../pages/CustomerReceipts";
 
 const router = createBrowserRouter([
   {
@@ -46,6 +47,10 @@ const router = createBrowserRouter([
           {
             path: "/supplier-payments",
             element: <SupplierPayments />,
+          },
+          {
+            path: "/customer-receipts",
+            element: <CustomerReceipts />,
           },
           {
             path: "/supplier-management",

--- a/client/src/services/apiSlice.js
+++ b/client/src/services/apiSlice.js
@@ -24,6 +24,8 @@ export const apiSlice = createApi({
     "SeedSales",
     "Inventory",
     "SupplierPayment",
+    "CustomerReceipt",
+    "Customer",
     "User",
   ],
   endpoints: () => ({}),

--- a/client/src/services/customerReceiptApi.js
+++ b/client/src/services/customerReceiptApi.js
@@ -1,0 +1,44 @@
+import { apiSlice } from "./apiSlice";
+
+export const customerReceiptApi = apiSlice.injectEndpoints({
+  endpoints: (builder) => ({
+    getReceipts: builder.query({
+      query: () => "/customer-receipts",
+      providesTags: ["CustomerReceipt"],
+    }),
+    getReceipt: builder.query({
+      query: (id) => `/customer-receipts/${id}`,
+    }),
+    createReceipt: builder.mutation({
+      query: (data) => ({
+        url: "/customer-receipts",
+        method: "POST",
+        body: data,
+      }),
+      invalidatesTags: ["CustomerReceipt", "Customer", "Sales"],
+    }),
+    updateReceipt: builder.mutation({
+      query: ({ id, ...data }) => ({
+        url: `/customer-receipts/${id}`,
+        method: "PUT",
+        body: data,
+      }),
+      invalidatesTags: ["CustomerReceipt", "Customer", "Sales"],
+    }),
+    deleteReceipt: builder.mutation({
+      query: (id) => ({
+        url: `/customer-receipts/${id}`,
+        method: "DELETE",
+      }),
+      invalidatesTags: ["CustomerReceipt", "Customer", "Sales"],
+    }),
+  }),
+});
+
+export const {
+  useGetReceiptsQuery,
+  useGetReceiptQuery,
+  useCreateReceiptMutation,
+  useUpdateReceiptMutation,
+  useDeleteReceiptMutation,
+} = customerReceiptApi;

--- a/server/controllers/customerReceiptController.js
+++ b/server/controllers/customerReceiptController.js
@@ -1,0 +1,155 @@
+const CustomerReceipt = require("../models/CustomerReceipt");
+const Sale = require("../models/Sale");
+const Customer = require("../models/Customer");
+
+const applyPayment = async (saleId, amount) => {
+  const sale = await Sale.findById(saleId);
+  if (!sale) return { error: "Sale not found" };
+  const outstanding = (sale.totalAmount || 0) - (sale.amountPaid || 0);
+  if (amount > outstanding) {
+    return { error: "Payment exceeds outstanding amount" };
+  }
+  sale.amountPaid = (sale.amountPaid || 0) + amount;
+  await sale.save();
+  return { sale };
+};
+
+const revertPayment = async (saleId, amount) => {
+  const sale = await Sale.findById(saleId);
+  if (!sale) return;
+  sale.amountPaid = (sale.amountPaid || 0) - amount;
+  if (sale.amountPaid < 0) sale.amountPaid = 0;
+  await sale.save();
+};
+
+exports.createReceipt = async (req, res) => {
+  try {
+    const { customer, invoices, paymentMode, referenceNo, paymentDate } = req.body;
+    if (!Array.isArray(invoices) || invoices.length === 0) {
+      return res.status(400).json({ error: "Invoices are required" });
+    }
+    let total = 0;
+    for (const item of invoices) {
+      const result = await applyPayment(item.sale, item.amount);
+      if (result.error) return res.status(400).json({ error: result.error });
+      total += item.amount;
+    }
+    const receipt = new CustomerReceipt({
+      customer,
+      invoices,
+      paymentMode,
+      referenceNo,
+      paymentDate,
+      totalAmount: total,
+    });
+    await receipt.save();
+
+    const cust = await Customer.findById(customer);
+    if (cust) {
+      cust.outstandingBalance = (cust.outstandingBalance || 0) - total;
+      await cust.save();
+    }
+
+    res.status(201).json(receipt);
+  } catch (error) {
+    res.status(400).json({ error: "Failed to create receipt", details: error.message });
+  }
+};
+
+exports.getAllReceipts = async (req, res) => {
+  try {
+    const receipts = await CustomerReceipt.find({ isDeleted: false })
+      .populate("customer")
+      .populate("invoices.sale");
+    res.json(receipts);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+};
+
+exports.getReceiptById = async (req, res) => {
+  try {
+    const receipt = await CustomerReceipt.findById(req.params.id)
+      .populate("customer")
+      .populate("invoices.sale");
+    if (!receipt || receipt.isDeleted) return res.status(404).json({ error: "Receipt not found" });
+    res.json(receipt);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+};
+
+exports.updateReceipt = async (req, res) => {
+  try {
+    const receipt = await CustomerReceipt.findById(req.params.id);
+    if (!receipt || receipt.isDeleted) return res.status(404).json({ error: "Receipt not found" });
+
+    // revert previous payments
+    let oldTotal = 0;
+    for (const item of receipt.invoices) {
+      await revertPayment(item.sale, item.amount);
+      oldTotal += item.amount;
+    }
+    const customer = await Customer.findById(receipt.customer);
+    if (customer) {
+      customer.outstandingBalance = (customer.outstandingBalance || 0) + oldTotal;
+      await customer.save();
+    }
+
+    // apply new payments
+    const { invoices, paymentMode, referenceNo, paymentDate, customer: newCust } = req.body;
+    if (!Array.isArray(invoices) || invoices.length === 0) {
+      return res.status(400).json({ error: "Invoices are required" });
+    }
+    let newTotal = 0;
+    for (const item of invoices) {
+      const result = await applyPayment(item.sale, item.amount);
+      if (result.error) return res.status(400).json({ error: result.error });
+      newTotal += item.amount;
+    }
+
+    const cust = await Customer.findById(newCust || receipt.customer);
+    if (cust) {
+      cust.outstandingBalance = (cust.outstandingBalance || 0) - newTotal;
+      await cust.save();
+    }
+
+    receipt.customer = newCust || receipt.customer;
+    receipt.invoices = invoices;
+    receipt.paymentMode = paymentMode;
+    receipt.referenceNo = referenceNo;
+    receipt.paymentDate = paymentDate;
+    receipt.totalAmount = newTotal;
+    await receipt.save();
+
+    res.json(receipt);
+  } catch (error) {
+    res.status(400).json({ error: "Failed to update receipt", details: error.message });
+  }
+};
+
+exports.deleteReceipt = async (req, res) => {
+  try {
+    const receipt = await CustomerReceipt.findById(req.params.id);
+    if (!receipt || receipt.isDeleted) return res.status(404).json({ error: "Receipt not found" });
+
+    let total = 0;
+    for (const item of receipt.invoices) {
+      await revertPayment(item.sale, item.amount);
+      total += item.amount;
+    }
+    const customer = await Customer.findById(receipt.customer);
+    if (customer) {
+      customer.outstandingBalance = (customer.outstandingBalance || 0) + total;
+      await customer.save();
+    }
+
+    receipt.isDeleted = true;
+    receipt.deletedAt = new Date();
+    await receipt.save();
+
+    res.json({ message: "Receipt deleted" });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+};

--- a/server/models/Customer.js
+++ b/server/models/Customer.js
@@ -34,6 +34,10 @@ const customerSchema = new mongoose.Schema(
       type: Number,
       default: 0,
     },
+    outstandingBalance: {
+      type: Number,
+      default: 0,
+    },
     paymentMode: {
       type: String,
       enum: ["cash", "credit"],

--- a/server/models/CustomerReceipt.js
+++ b/server/models/CustomerReceipt.js
@@ -1,0 +1,37 @@
+const mongoose = require("mongoose");
+
+const receiptItemSchema = new mongoose.Schema(
+  {
+    sale: { type: mongoose.Schema.Types.ObjectId, ref: "Sale", required: true },
+    amount: { type: Number, required: true },
+  },
+  { _id: false }
+);
+
+const customerReceiptSchema = new mongoose.Schema(
+  {
+    customer: { type: mongoose.Schema.Types.ObjectId, ref: "Customer", required: true },
+    invoices: { type: [receiptItemSchema], required: true },
+    totalAmount: { type: Number, required: true },
+    receiptNumber: { type: String, unique: true },
+    paymentDate: { type: Date, default: Date.now },
+    paymentMode: {
+      type: String,
+      enum: ["cash", "upi", "bank", "cheque"],
+      required: true,
+    },
+    referenceNo: String,
+    isDeleted: { type: Boolean, default: false },
+    approved: { type: Boolean, default: false },
+  },
+  { timestamps: true }
+);
+
+customerReceiptSchema.pre("save", function (next) {
+  if (!this.receiptNumber) {
+    this.receiptNumber = `RCPT-${Date.now()}`;
+  }
+  next();
+});
+
+module.exports = mongoose.model("CustomerReceipt", customerReceiptSchema);

--- a/server/routes/customerReceiptRoutes.js
+++ b/server/routes/customerReceiptRoutes.js
@@ -1,0 +1,11 @@
+const express = require("express");
+const router = express.Router();
+const controller = require("../controllers/customerReceiptController");
+
+router.post("/", controller.createReceipt);
+router.get("/", controller.getAllReceipts);
+router.get("/:id", controller.getReceiptById);
+router.put("/:id", controller.updateReceipt);
+router.delete("/:id", controller.deleteReceipt);
+
+module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -11,6 +11,7 @@ const supplierRoutes = require("./routes/supplierRoutes");
 const customerRoutes = require("./routes/CustomerRoutes");
 const lotRoutes = require("./routes/lotRoutes");
 const supplierPaymentRoutes = require("./routes/supplierPaymentRoutes");
+const customerReceiptRoutes = require("./routes/customerReceiptRoutes");
 
 dotenv.config();
 connectDB();
@@ -25,6 +26,7 @@ app.use("/api/sales", saleRoutes);
 app.use("/api/auth", authRoutes);
 app.use("/api/suppliers", supplierRoutes);
 app.use("/api/supplier-payments", supplierPaymentRoutes);
+app.use("/api/customer-receipts", customerReceiptRoutes);
 app.use("/api/customers", customerRoutes);
 app.use("/api", storageRoutes);
 app.use("/api/purchases", require("./routes/purchaseRoutes"));


### PR DESCRIPTION
## Summary
- add Customer Receipts API client
- implement receipt form modal and page
- link new page in routes and sidebar
- expose new tags in `apiSlice`
- document Customer Receipts page in README

## Testing
- `node --check client/src/services/customerReceiptApi.js`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685f875969308320845536df4f50a864