### PR TITLE
Add reporting module

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ per customer.
 The frontend includes a **Customer Receipts** page accessible from the sidebar
 menu. Use it to record payments received and manage existing receipts.
 
+## Reports Module
+
+The application includes a dedicated Reports page accessible from the sidebar.
+Use it to view summaries for purchases, sales, transfers, processing, current
+stock and payment history. Select a report type and date range to fetch data
+from the backend endpoints under `/api/reports`. Results are shown in a table
+and a simple bar chart for quick visual reference.
+
 ### Running the Frontend
 
 From the repository root:

--- a/client/src/layouts/Sidebar.jsx
+++ b/client/src/layouts/Sidebar.jsx
@@ -38,6 +38,7 @@ const menuItems = [
   { text: "Sales", icon: <AccountBalance />, path: "/sales" },
   { text: "Supplier Payments", icon: <Inventory />, path: "/supplier-payments" },
   { text: "Customer Receipts", icon: <PeopleOutlineOutlined />, path: "/customer-receipts" },
+  { text: "Reports", icon: <Diversity3Outlined />, path: "/reports" },
   {
     text: "Supplier Management",
     icon: <Business />,

--- a/client/src/pages/Reports.jsx
+++ b/client/src/pages/Reports.jsx
@@ -1,0 +1,237 @@
+import {
+  Box,
+  Typography,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  Select,
+  MenuItem,
+  FormControl,
+  InputLabel,
+  Button,
+} from "@mui/material";
+import { useState, useMemo } from "react";
+import {
+  useGetPurchaseReportQuery,
+  useGetSalesReportQuery,
+  useGetTransferReportQuery,
+  useGetProcessingReportQuery,
+  useGetStockReportQuery,
+  useGetPaymentsReportQuery,
+} from "../services/reportsApi";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+
+const REPORT_OPTIONS = [
+  { value: "purchases", label: "Purchases" },
+  { value: "sales", label: "Sales" },
+  { value: "transfers", label: "Transfers" },
+  { value: "processing", label: "Processing" },
+  { value: "stock", label: "Stock" },
+  { value: "payments", label: "Payments" },
+];
+
+const Reports = () => {
+  const [filters, setFilters] = useState({ startDate: "", endDate: "" });
+  const [type, setType] = useState("purchases");
+
+  const params = useMemo(() => {
+    const p = new URLSearchParams();
+    if (filters.startDate && filters.endDate) {
+      p.append("startDate", filters.startDate);
+      p.append("endDate", filters.endDate);
+    }
+    return p.toString();
+  }, [filters]);
+
+  const purchaseQuery = useGetPurchaseReportQuery(params, {
+    skip: type !== "purchases",
+  });
+  const salesQuery = useGetSalesReportQuery(params, {
+    skip: type !== "sales",
+  });
+  const transferQuery = useGetTransferReportQuery(params, {
+    skip: type !== "transfers",
+  });
+  const processingQuery = useGetProcessingReportQuery(params, {
+    skip: type !== "processing",
+  });
+  const stockQuery = useGetStockReportQuery(params, {
+    skip: type !== "stock",
+  });
+  const paymentsQuery = useGetPaymentsReportQuery(params, {
+    skip: type !== "payments",
+  });
+
+  const data =
+    purchaseQuery.data ||
+    salesQuery.data ||
+    transferQuery.data ||
+    processingQuery.data ||
+    stockQuery.data?.storages ||
+    paymentsQuery.data ||
+    [];
+
+  const getColumns = () => {
+    switch (type) {
+      case "sales":
+        return [
+          { label: "Customer", field: "customerName" },
+          { label: "Quantity", field: "quantity" },
+          { label: "Value", field: "value" },
+          { label: "Outstanding", field: "outstanding" },
+        ];
+      case "transfers":
+        return [
+          { label: "From", field: "fromStorage" },
+          { label: "To", field: "toStorage" },
+          { label: "Type", field: "tamarindType" },
+          { label: "Qty", field: "quantity" },
+        ];
+      case "processing":
+        return [
+          { label: "Unit", field: "unitName" },
+          { label: "Input", field: "totalInput" },
+          { label: "Output", field: "totalOutput" },
+          { label: "Loss", field: "totalWeightLoss" },
+          { label: "Efficiency", field: "efficiency" },
+        ];
+      case "stock":
+        return [
+          { label: "Storage", field: "storageName" },
+          { label: "Type", field: "type" },
+          { label: "Quantity", field: "quantity" },
+        ];
+      case "payments":
+        return [
+          { label: "Name", field: "supplierName" },
+          { label: "Total", field: "totalPaid" },
+          { label: "Count", field: "payments" },
+          { label: "Outstanding", field: "outstanding" },
+        ];
+      default:
+        return [
+          { label: "Supplier", field: "supplierName" },
+          { label: "Total Qty", field: "totalQuantity" },
+          { label: "Total Amount", field: "totalAmount" },
+          { label: "Outstanding", field: "outstanding" },
+        ];
+    }
+  };
+
+  const columns = getColumns();
+
+  const chartData = Array.isArray(data)
+    ? data.map((row) => ({
+        name:
+          row.supplierName ||
+          row.customerName ||
+          row.unitName ||
+          row.fromStorage ||
+          row.storageName ||
+          "", 
+        value:
+          row.totalAmount ||
+          row.value ||
+          row.quantity ||
+          row.totalOutput ||
+          row.totalPaid ||
+          row.totalReceived ||
+          0,
+      }))
+    : [];
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFilters((prev) => ({ ...prev, [name]: value }));
+  };
+
+  return (
+    <Box>
+      <Box
+        display="flex"
+        justifyContent="space-between"
+        alignItems="center"
+        mb={2}
+      >
+        <Typography variant="h5" textTransform="capitalize">
+          {type} Report
+        </Typography>
+      </Box>
+      <Box mb={2} display="flex" gap={2} flexWrap="wrap">
+        <FormControl size="small" sx={{ minWidth: 160 }}>
+          <InputLabel id="report-type">Report</InputLabel>
+          <Select
+            labelId="report-type"
+            label="Report"
+            value={type}
+            onChange={(e) => setType(e.target.value)}
+          >
+            {REPORT_OPTIONS.map((opt) => (
+              <MenuItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <input
+          type="date"
+          name="startDate"
+          value={filters.startDate}
+          onChange={handleChange}
+        />
+        <input
+          type="date"
+          name="endDate"
+          value={filters.endDate}
+          onChange={handleChange}
+        />
+      </Box>
+      <TableContainer component={Paper} sx={{ mb: 3 }}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              {columns.map((c) => (
+                <TableCell key={c.field}>{c.label}</TableCell>
+              ))}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {Array.isArray(data) &&
+              data.map((row, idx) => (
+                <TableRow key={row._id || idx}>
+                  {columns.map((c) => (
+                    <TableCell key={c.field}>{row[c.field] ?? "-"}</TableCell>
+                  ))}
+                </TableRow>
+              ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      {chartData.length > 0 && (
+        <Box height={300}>
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={chartData}>
+              <XAxis dataKey="name" />
+              <YAxis />
+              <Tooltip />
+              <Bar dataKey="value" fill="#1976d2" />
+            </BarChart>
+          </ResponsiveContainer>
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default Reports;

--- a/client/src/routes/AppRoutes.jsx
+++ b/client/src/routes/AppRoutes.jsx
@@ -12,6 +12,7 @@ import CustomerPage from "../pages/CustomerPage";
 import StorageAndLotPage from "../pages/StorageAndLotPage";
 import SupplierPayments from "../pages/SupplierPayments";
 import CustomerReceipts from "../pages/CustomerReceipts";
+import Reports from "../pages/Reports";
 
 const router = createBrowserRouter([
   {
@@ -43,6 +44,10 @@ const router = createBrowserRouter([
           {
             path: "/sales",
             element: <Sales />,
+          },
+          {
+            path: "/reports",
+            element: <Reports />,
           },
           {
             path: "/supplier-payments",

--- a/client/src/services/reportsApi.js
+++ b/client/src/services/reportsApi.js
@@ -1,0 +1,33 @@
+import { apiSlice } from "./apiSlice";
+
+export const reportsApi = apiSlice.injectEndpoints({
+  endpoints: (builder) => ({
+    getPurchaseReport: builder.query({
+      query: (params) => `/reports/purchases?${params}`,
+    }),
+    getSalesReport: builder.query({
+      query: (params) => `/reports/sales?${params}`,
+    }),
+    getTransferReport: builder.query({
+      query: (params) => `/reports/transfers?${params}`,
+    }),
+    getProcessingReport: builder.query({
+      query: (params) => `/reports/processing?${params}`,
+    }),
+    getStockReport: builder.query({
+      query: (params) => `/reports/stock?${params}`,
+    }),
+    getPaymentsReport: builder.query({
+      query: (params) => `/reports/payments?${params}`,
+    }),
+  }),
+});
+
+export const {
+  useGetPurchaseReportQuery,
+  useGetSalesReportQuery,
+  useGetTransferReportQuery,
+  useGetProcessingReportQuery,
+  useGetStockReportQuery,
+  useGetPaymentsReportQuery,
+} = reportsApi;

--- a/server/controllers/reportController.js
+++ b/server/controllers/reportController.js
@@ -1,0 +1,282 @@
+const Purchase = require("../models/Purchase");
+const Sale = require("../models/Sale");
+const Transfer = require("../models/Transfer.model");
+const Processing = require("../models/Processing");
+const SupplierPayment = require("../models/SupplierPayment");
+const CustomerReceipt = require("../models/CustomerReceipt");
+const Supplier = require("../models/Supplier");
+const Customer = require("../models/Customer");
+const Storage = require("../models/Storage");
+const Lot = require("../models/Lot");
+
+const parseDateRange = (start, end, field = "createdAt") => {
+  const match = {};
+  if (start && end) {
+    match[field] = { $gte: new Date(start), $lte: new Date(end) };
+  }
+  return match;
+};
+
+// Purchase report grouped by supplier
+exports.purchases = async (req, res) => {
+  try {
+    const { startDate, endDate, supplier, paymentType } = req.query;
+    const match = { ...parseDateRange(startDate, endDate, "purchaseDate") };
+    if (supplier) match.supplierId = supplier;
+    if (paymentType) match.paymentType = paymentType;
+
+    const data = await Purchase.aggregate([
+      { $match: match },
+      { $unwind: "$tamarindItems" },
+      {
+        $group: {
+          _id: "$supplierId",
+          totalQuantity: { $sum: "$tamarindItems.quantity" },
+          totalAmount: { $sum: "$tamarindItems.totalAmount" },
+        },
+      },
+      { $lookup: { from: "suppliers", localField: "_id", foreignField: "_id", as: "supplier" } },
+      { $unwind: "$supplier" },
+      {
+        $project: {
+          supplierId: "$_id",
+          supplierName: "$supplier.name",
+          totalQuantity: 1,
+          totalAmount: 1,
+          outstanding: "$supplier.outstandingBalance",
+        },
+      },
+    ]);
+
+    res.json(data);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+};
+
+// Sales report grouped by customer
+exports.sales = async (req, res) => {
+  try {
+    const { startDate, endDate, customer, paymentType } = req.query;
+    const match = { ...parseDateRange(startDate, endDate, "invoiceDate") };
+    if (customer) match.customer = customer;
+    if (paymentType) match.paymentType = paymentType;
+
+    const data = await Sale.aggregate([
+      { $match: match },
+      { $unwind: "$items" },
+      {
+        $group: {
+          _id: "$customer",
+          quantity: { $sum: "$items.quantity" },
+          value: { $sum: "$items.total" },
+        },
+      },
+      { $lookup: { from: "customers", localField: "_id", foreignField: "_id", as: "customer" } },
+      { $unwind: "$customer" },
+      {
+        $project: {
+          customerId: "$_id",
+          customerName: "$customer.name",
+          quantity: 1,
+          value: 1,
+          outstanding: "$customer.outstandingBalance",
+        },
+      },
+    ]);
+
+    res.json(data);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+};
+
+// Transfer report summarised by source and destination
+exports.transfers = async (req, res) => {
+  try {
+    const { startDate, endDate, fromStorage, toStorage } = req.query;
+    const match = { ...parseDateRange(startDate, endDate, "transferDate") };
+    if (fromStorage) match.fromStorageId = fromStorage;
+    if (toStorage) match.toStorageId = toStorage;
+
+    const data = await Transfer.aggregate([
+      { $match: match },
+      {
+        $group: {
+          _id: { from: "$fromStorageId", to: "$toStorageId", type: "$tamarindType" },
+          quantity: { $sum: "$quantity" },
+        },
+      },
+      { $lookup: { from: "storages", localField: "_id.from", foreignField: "_id", as: "from" } },
+      { $unwind: "$from" },
+      { $lookup: { from: "storages", localField: "_id.to", foreignField: "_id", as: "to" } },
+      { $unwind: "$to" },
+      {
+        $project: {
+          fromStorage: "$from.name",
+          toStorage: "$to.name",
+          tamarindType: "$_id.type",
+          quantity: 1,
+        },
+      },
+      { $sort: { fromStorage: 1, toStorage: 1 } },
+    ]);
+
+    res.json(data);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+};
+
+// Processing efficiency per manufacturing unit
+exports.processing = async (req, res) => {
+  try {
+    const { startDate, endDate, unit } = req.query;
+    const match = { ...parseDateRange(startDate, endDate, "date") };
+    if (unit) match.manufacturingUnit = unit;
+
+    const data = await Processing.aggregate([
+      { $match: match },
+      {
+        $group: {
+          _id: "$manufacturingUnit",
+          totalInput: { $sum: "$totalInputQuantity" },
+          totalOutput: { $sum: "$output.quantity" },
+          totalWeightLoss: { $sum: "$weightLoss.quantity" },
+        },
+      },
+      { $lookup: { from: "storages", localField: "_id", foreignField: "_id", as: "unit" } },
+      { $unwind: "$unit" },
+      {
+        $project: {
+          unitId: "$_id",
+          unitName: "$unit.name",
+          totalInput: 1,
+          totalOutput: 1,
+          totalWeightLoss: 1,
+          efficiency: {
+            $cond: [
+              { $eq: ["$totalInput", 0] },
+              0,
+              { $divide: ["$totalOutput", "$totalInput"] },
+            ],
+          },
+        },
+      },
+      { $sort: { unitName: 1 } },
+    ]);
+
+    res.json(data);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+};
+
+// Current stock levels per storage
+exports.stock = async (req, res) => {
+  try {
+    const { storageId, tamarindType } = req.query;
+    const storageMatch = storageId ? { _id: storageId } : {};
+
+    const storages = await Storage.find(storageMatch);
+    const lotMatch = { isActive: true };
+    if (storageId) lotMatch.coldStorageId = storageId;
+    if (tamarindType) lotMatch.tamarindType = tamarindType;
+
+    const lots = await Lot.aggregate([
+      { $match: lotMatch },
+      {
+        $group: {
+          _id: { storage: "$coldStorageId", type: "$tamarindType" },
+          quantity: { $sum: "$quantity" },
+        },
+      },
+    ]);
+
+    const coldMap = {};
+    lots.forEach((l) => {
+      const sid = l._id.storage.toString();
+      if (!coldMap[sid]) coldMap[sid] = {};
+      coldMap[sid][l._id.type] = l.quantity;
+    });
+
+    const result = storages.map((s) => ({
+      storageId: s._id,
+      storageName: s.name,
+      type: s.type,
+      quantity: s.quantity,
+      lots: coldMap[s._id.toString()] || {},
+    }));
+
+    const total = result.reduce((sum, r) => {
+      if (r.type === "cold") {
+        return sum + Object.values(r.lots).reduce((a, b) => a + b, 0);
+      }
+      return sum + (r.quantity || 0);
+    }, 0);
+
+    res.json({ total, storages: result });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+};
+
+// Supplier payments or customer receipts summary
+exports.payments = async (req, res) => {
+  try {
+    const { startDate, endDate, type } = req.query; // type: supplier or customer
+    const match = parseDateRange(startDate, endDate, "paymentDate");
+
+    if (type === "supplier") {
+      const data = await SupplierPayment.aggregate([
+        { $match: match },
+        {
+          $group: {
+            _id: "$supplier",
+            totalPaid: { $sum: "$amount" },
+            count: { $sum: 1 },
+          },
+        },
+        { $lookup: { from: "suppliers", localField: "_id", foreignField: "_id", as: "supplier" } },
+        { $unwind: "$supplier" },
+        {
+          $project: {
+            supplierId: "$_id",
+            supplierName: "$supplier.name",
+            totalPaid: 1,
+            payments: "$count",
+            outstanding: "$supplier.outstandingBalance",
+          },
+        },
+        { $sort: { supplierName: 1 } },
+      ]);
+      res.json(data);
+    } else {
+      const data = await CustomerReceipt.aggregate([
+        { $match: match },
+        {
+          $group: {
+            _id: "$customer",
+            totalReceived: { $sum: "$totalAmount" },
+            count: { $sum: 1 },
+          },
+        },
+        { $lookup: { from: "customers", localField: "_id", foreignField: "_id", as: "customer" } },
+        { $unwind: "$customer" },
+        {
+          $project: {
+            customerId: "$_id",
+            customerName: "$customer.name",
+            totalReceived: 1,
+            receipts: "$count",
+            outstanding: "$customer.outstandingBalance",
+          },
+        },
+        { $sort: { customerName: 1 } },
+      ]);
+      res.json(data);
+    }
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+};

--- a/server/routes/reportRoutes.js
+++ b/server/routes/reportRoutes.js
@@ -1,0 +1,12 @@
+const express = require("express");
+const router = express.Router();
+const controller = require("../controllers/reportController");
+
+router.get("/purchases", controller.purchases);
+router.get("/sales", controller.sales);
+router.get("/transfers", controller.transfers);
+router.get("/processing", controller.processing);
+router.get("/stock", controller.stock);
+router.get("/payments", controller.payments);
+
+module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -12,6 +12,7 @@ const customerRoutes = require("./routes/CustomerRoutes");
 const lotRoutes = require("./routes/lotRoutes");
 const supplierPaymentRoutes = require("./routes/supplierPaymentRoutes");
 const customerReceiptRoutes = require("./routes/customerReceiptRoutes");
+const reportRoutes = require("./routes/reportRoutes");
 
 dotenv.config();
 connectDB();
@@ -31,6 +32,7 @@ app.use("/api/customers", customerRoutes);
 app.use("/api", storageRoutes);
 app.use("/api/purchases", require("./routes/purchaseRoutes"));
 app.use("/api", lotRoutes);
+app.use("/api/reports", reportRoutes);
 
 app.get("/", (req, res) => {
   res.send("Tamarind Tracker API is running...");


### PR DESCRIPTION
## Summary
- add backend report endpoints
- integrate reports routes in the server
- create React API service and page for viewing purchase reports
- expose reports page in routes and sidebar
- document the new module
- refine backend aggregation logic for reports
- enhance frontend reports page with dropdown selection and charts

## Testing
- `npm --prefix client run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*


------
https://chatgpt.com/codex/tasks/task_e_685f9052cc6c83208f819f22dd1083df